### PR TITLE
Feature Request: Add browser support with isomorphic-crypto

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {randomBytes} = require('crypto')
+const {randomBytes} = require('isomorphic-crypto')
 const {inspect: {custom: customInspectSymbol}} = require('util')
 const padStart = require('string.prototype.padstart')
 const base62 = require('./base62')

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
   },
   "homepage": "https://github.com/novemberborn/ksuid#readme",
   "dependencies": {
-    "string.prototype.padstart": "^3.0.0"
+    "isomorphic-crypto": "^3.0.0",
+    "string.prototype.padstart": "^3.0.0",
+    "util": "^0.11.0"
   },
   "devDependencies": {
     "@novemberborn/as-i-preach": "^10.1.0",


### PR DESCRIPTION
[`isomorphic-crypto`](https://www.npmjs.com/package/isomorphic-crypto) switches between the native `crypto` and [`crypto-browserify`](https://www.npmjs.com/package/crypto-browserify) depending on if it's in the browser or not.

I published this PR to `@therebel/ksuid` on npm and tested it in my own application; it seems to be working great! Thanks so much for making this lib!