### PR TITLE
Add optional date to random() & randomSync()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Install and test package
-on: push
+on: [push, pull_request]
 jobs:
   nodejs:
     name: Node.js

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Or asynchronously:
 const ksuidFromAsync = await KSUID.random()
 ```
 
+You can also specify a specific time, either in milliseconds or as a `Date` object:
+
+```js
+const ksuidFromDate = KSUID.randomSync(new Date("2014-05-25T16:53:20Z"))
+const ksuidFromMillisecondsAsync = await KSUID.random(1401036800000)
+```
+
 Or you can compose it using a timestamp and a 16-byte payload:
 
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,11 @@ declare class KSUID {
     equals(other: KSUID): boolean;
     toString(): string;
     static random(): Promise<KSUID>;
+    static random(timeInMs: number): Promise<KSUID>;
+    static random(date: Date): Promise<KSUID>;
     static randomSync(): KSUID;
+    static randomSync(timeInMs: number): KSUID;
+    static randomSync(date: Date): KSUID;
     static fromParts(timeInMs: number, payload: Buffer): KSUID;
     static isValid(buffer: Buffer): boolean;
     static parse(str: string): KSUID;

--- a/index.js
+++ b/index.js
@@ -99,14 +99,14 @@ class KSUID {
     return this.toString()
   }
 
-  static async random () {
+  static async random (time = Date.now()) {
     const payload = await asyncRandomBytes(PAYLOAD_BYTE_LENGTH)
-    return new KSUID(fromParts(Date.now(), payload))
+    return new KSUID(fromParts(Number(time), payload))
   }
 
-  static randomSync () {
+  static randomSync (time = Date.now()) {
     const payload = randomBytes(PAYLOAD_BYTE_LENGTH)
-    return new KSUID(fromParts(Date.now(), payload))
+    return new KSUID(fromParts(Number(time), payload))
   }
 
   static fromParts (timeInMs, payload) {

--- a/test/ksuid.js
+++ b/test/ksuid.js
@@ -18,6 +18,30 @@ test.serial('provides the uncorrected timestamp in seconds', t => {
   t.is(x.timestamp * 1e3, Date.now() - 14e11)
 })
 
+test('random accepts milliseconds value', async t => {
+  const ms = (new Date(2025, 4, 15)).getTime()
+  const x = await KSUID.random(ms)
+  t.is(x.timestamp * 1e3, ms - 14e11)
+})
+
+test('randomSync accepts milliseconds value', t => {
+  const ms = (new Date(2025, 4, 15)).getTime()
+  const x = KSUID.randomSync(ms)
+  t.is(x.timestamp * 1e3, ms - 14e11)
+})
+
+test('random accepts date value', async t => {
+  const d = new Date(2014, 4, 15)
+  const x = await KSUID.random(d)
+  t.is(x.timestamp * 1e3, d.getTime() - 14e11)
+})
+
+test('randomSync accepts date value', t => {
+  const d = new Date(2014, 4, 15)
+  const x = KSUID.randomSync(d)
+  t.is(x.timestamp * 1e3, d.getTime() - 14e11)
+})
+
 test('encodes as a string', t => {
   const x = new KSUID(Buffer.alloc(20))
   const expected = '0'.repeat(27)


### PR DESCRIPTION
This is meant to fix #17 

I added support for Date and number arguments for `random` and `randomSync`.  Added some tests to cover it.  And upgraded some dependencies that were a little too annoying on `npm i`, and causing issues with node 12.